### PR TITLE
Improve handling of certain fixtures types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "firefox-profile": "^0.4.2",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.5",
-    "html-normalizer": "^6.0.0",
+    "html-normalizer": "^7.0.2",
     "istanbul": "^0.4.4",
     "jquery": "^2.2.3",
     "jsdom": "^9.2.0",


### PR DESCRIPTION
By updating html-normalizer to 7.0.2, marko-tester is now capable of handling:

- plain text (e.g. `"plain text"`)
- multiple root siblings (e.g. `<div>1</div><div>2</div>`)
- table fragments in fixtures (e.g. `<tbody><tr><td>1</td></tr></tbody>`)

See: https://github.com/TimothyRHuertas/normalizer/pull/13