### PR TITLE
Don't enforce named functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   },
   "rules": {
     "vars-on-top": 0,
-    "no-param-reassign": 0
+    "no-param-reassign": 0,
+    "func-names": 0
   }
 }


### PR DESCRIPTION
When eslint is linting test files it will complain about unnamed functions when it hits:

```javascript
describe('foo', function () {
  // -----------^
});
```

I propose therefore that we don't enforce named functions.