### PR TITLE
Add possibility to auto-fix linter issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ npm install --save-dev marko-tester
 
 ### CLI
 
-Once you've installed marko-tester, you can start using the `markotester` alias with the path to your source folder. There are few arguments you can pass if needed: `--no-coverage` if you don't want to generate coverage report; `--no-mocha` if you want to execute only linting; `--no-lint` if you don't want lint checks. Also you can try out `--with-acceptance` for running acceptance tests (keep in mind, with this flag in place unit-tests won't be executed).
+Once you've installed marko-tester, you can start using the `markotester` alias with the path to your source folder. There are few arguments you can pass if needed:
+
+- `--no-coverage` if you don't want to generate coverage report
+- `--no-mocha` if you want to execute only linting
+- `--no-lint` if you don't want lint checks
+- `--fix-lint` if you want to automatically fix your linting issues
+- `--with-acceptance` for running acceptance tests (keep in mind, with this flag in place unit-tests won't be executed)
 
 ```
 markotester source --no-coverage
 markotester source --no-coverage --no-lint
 markotester source --with-acceptance
+markotester source --fix-lint
 ```
 
 ### File structure
@@ -213,7 +220,7 @@ tester('source/pages/index', function(expect, browser) {
   before(function () {
     page = browser().url('/hello-world');
   });
-  
+
   it('should have a title', function (done) {
     expect(page.getTitle()).to.eventually.be.equal('hello world').and.notify(done);
   });

--- a/source/utils.js
+++ b/source/utils.js
@@ -36,6 +36,7 @@ module.exports = {
         outputPath: path.join(__dirname, '..', 'static'),
         withCoverage: process.argv.indexOf('--with-acceptance') === -1 && process.argv.indexOf('--no-coverage') === -1,
         withLint: process.argv.indexOf('--no-lint') === -1,
+        withFix: process.argv.indexOf('--fix-lint') > -1,
         withMocha: process.argv.indexOf('--with-acceptance') === -1 && process.argv.indexOf('--no-mocha') === -1,
         withAcceptance: process.argv.indexOf('--with-acceptance') > -1,
         config: markoTesterConfig


### PR DESCRIPTION
This PR adds the possibility to opt-in for auto-fixing js style issues via eslint. I also looked into enabling auto-fixes for css/less issues but this is a bit more complicated.