### PR TITLE
Allow disabling statements in stylelint

### DIFF
--- a/source/testers/lint.js
+++ b/source/testers/lint.js
@@ -95,8 +95,7 @@ function testLint(done) {
     .lint({
       files: sourcePaths.map(getLessGlob),
       config: stylelintConfig,
-      formatter: 'string',
-      ignoreDisables: true
+      formatter: 'string'
     })
     .then(parseStylelintData)
     .catch(function handleStylelintError(err) {


### PR DESCRIPTION
There are a lot of handy helpers to ignore certain rules for special edge cases. I don't think it makes a lot of sense to ignore them.