### PR TITLE
Persist linter fixes only on actual changes

### DIFF
--- a/source/testers/lint.js
+++ b/source/testers/lint.js
@@ -47,7 +47,9 @@ function testLint(done) {
   }
 
   function persistFixes(report) {
-    report.results.forEach(function forEachResult(result) {
+    report.results.filter(function filterEmptyResult(result) {
+      return !!result.output;
+    }).forEach(function forEachResult(result) {
       fs.writeFileSync(result.filePath, result.output);
     });
   }


### PR DESCRIPTION
When you run --fix-lint on a file which is already fine it is overwritten with `undefined` 😊 