### PR TITLE
Show inline diff

### DIFF
--- a/source/testers/mocha.js
+++ b/source/testers/mocha.js
@@ -8,6 +8,7 @@ var utils = require('../utils');
 var mocha = new Mocha({
   ui: 'bdd',
   reporter: 'spec',
+  useInlineDiffs: true,
   grep: args.grep,
   ignoreLeaks: false,
   globals: ['document', 'window', 'GLOBAL_LASSO']


### PR DESCRIPTION
Show inline diff by default on report. This is on by default if you use mocha CLI (https://mochajs.org/#diffs).