### PR TITLE
Always render the table section so the lasso page is never reinitialized

### DIFF
--- a/source/builders/component.js
+++ b/source/builders/component.js
@@ -45,7 +45,6 @@ function buildComponent(context, opts, cb) {
   }
 
   var fixture = getFixture(context, options.fixture);
-  var layout = options.layout;
 
   options.mochaOperation('When component is being built', function whenComponentIsBeingBuilt() {
     this.buildWidget = buildWidget.bind(this, context);
@@ -62,7 +61,7 @@ function buildComponent(context, opts, cb) {
         done();
       }
 
-      context.preparePage(layout).then(buildDom);
+      context.preparePage().then(buildDom);
     });
 
     beforeEach(function (done) {
@@ -96,7 +95,8 @@ function buildComponent(context, opts, cb) {
         }
 
         if (Widget) {
-          var componentContainer = window['component-container'];
+          var layout = options.layout || 'container';
+          var componentContainer = window['component-' + layout];
 
           componentContainer.innerHTML = html;
 

--- a/source/builders/page.js
+++ b/source/builders/page.js
@@ -10,7 +10,6 @@ var Promise = require('bluebird');
 var utils = require('../utils');
 var coverage = require('../testers/coverage');
 var pagePrepared;
-var lastLayoutUsed;
 
 function buildPage(context, opts, cb) {
   var callback = cb || opts;
@@ -79,7 +78,7 @@ function createDom(htmlPath, resolve, reject) {
   );
 }
 
-function prepare(context, layout) {
+function prepare() {
   fs.ensureDirSync(utils.getHelpers().outputPath);
 
   var lassoPluginPaths = utils.getHelpers().config.lassoPlugins || [];
@@ -105,12 +104,6 @@ function prepare(context, layout) {
     bundlingEnabled: false
   });
 
-  if (layout !== lastLayoutUsed) {
-    pagePrepared = false;
-  }
-
-  lastLayoutUsed = layout;
-
   return new Promise(function promisePage(resolve, reject) {
     /* eslint global-require: 0 */
 
@@ -133,7 +126,7 @@ function prepare(context, layout) {
     buildDependencies();
 
     return require(path.resolve(__dirname, '../page.marko'))
-      .render({ layout: layout }, out)
+      .render({}, out)
       .on('finish', generateDom);
   });
 }

--- a/source/builders/widget.js
+++ b/source/builders/widget.js
@@ -9,6 +9,11 @@ function buildWidget(context, opts, cb) {
   options.mochaOperation('When widget is being rendered', function whenWidgetIsBeingRendered() {
     beforeEach(function buildWidgetBeforeEach() {
       var widgetContainers = window['component-container'].querySelectorAll('[data-widget]');
+
+      if (!widgetContainers.length) {
+        widgetContainers = window['component-table'].querySelectorAll('[data-widget]');
+      }
+
       var lastWidgetIndex = widgetContainers.length - 1;
       var widgetIds = [];
 

--- a/source/page.marko
+++ b/source/page.marko
@@ -9,8 +9,8 @@
     </head>
 
     <body>
-        <table if(data.layout === 'table') id="component-container"></table>
-        <div else id="component-container"></div>
+        <table id="component-table"></table>
+        <div id="component-container"></div>
         <div id="mocha"></div>
         <lasso-body/>
     </body>


### PR DESCRIPTION
Undoing some changes from yesterday, making sure the lasso page never gets reinitialized. Changes yesterday broke coverage reporting since the static folder was overwritten when the page was reinitialized. 