### PR TITLE
added a new global variable to mocha globals declaration

### DIFF
--- a/source/testers/mocha.js
+++ b/source/testers/mocha.js
@@ -17,7 +17,7 @@ var mocha = new Mocha({
       mochaFile: './.coverage/junit.xml'
     }
   },
-  globals: ['document', 'window', 'GLOBAL_LASSO']
+  globals: ['document', 'window', 'GLOBAL_LASSO', '$W10NOOP']
 });
 
 function testMocha(done) {


### PR DESCRIPTION
A new global variable introduced in marko - https://github.com/marko-js/warp10/pull/1.

This leads to mocha complaining `Error: global leak detected: $W10NOOP` resulting in test failures.