### PR TITLE
fix: added global variable 'version' to the mocha

### DIFF
--- a/source/testers/mocha.js
+++ b/source/testers/mocha.js
@@ -17,7 +17,7 @@ var mocha = new Mocha({
       mochaFile: './.coverage/junit.xml'
     }
   },
-  globals: ['document', 'window', 'GLOBAL_LASSO', '$W10NOOP']
+  globals: ['document', 'window', 'GLOBAL_LASSO', '$W10NOOP', 'version']
 });
 
 function testMocha(done) {


### PR DESCRIPTION
Mocha is complaining for the global variable `version`.

` Error: global leak detected: version`